### PR TITLE
don't suppress informative error message

### DIFF
--- a/workbench/metadataDeploy.php
+++ b/workbench/metadataDeploy.php
@@ -140,6 +140,10 @@ function printDeployOptions($deployOptions, $editable) {
 function validateZipFile($file) {
     $validationResult = validateUploadedFile($file);
 
+    if ($validationResult) {
+        return($validationResult);
+    }
+
     if (!isset($file["tmp_name"]) || $file["tmp_name"] == "") {
         return("No file uploaded for deployment.");
     }


### PR DESCRIPTION
An uploaded file was being rejected due to its size, but the user only received the error message "No file uploaded for deployment."

This PR surfaces the more informative message.