### PR TITLE
Latest 35.0 metadata wsdl with uiRequestId header property removed

### DIFF
--- a/workbench/soapclient/sforce.350.metadata.wsdl
+++ b/workbench/soapclient/sforce.350.metadata.wsdl
@@ -129,6 +129,7 @@ Copyright 2006-2015 Salesforce.com, inc. All Rights Reserved
    </xsd:simpleType>
    <xsd:complexType name="RunTestsResult">
     <xsd:sequence>
+     <xsd:element name="apexLogId" minOccurs="0" type="xsd:string"/>
      <xsd:element name="codeCoverage" minOccurs="0" maxOccurs="unbounded" type="tns:CodeCoverageResult"/>
      <xsd:element name="codeCoverageWarnings" minOccurs="0" maxOccurs="unbounded" type="tns:CodeCoverageWarning"/>
      <xsd:element name="failures" minOccurs="0" maxOccurs="unbounded" type="tns:RunTestFailure"/>
@@ -2467,8 +2468,6 @@ Copyright 2006-2015 Salesforce.com, inc. All Rights Reserved
     <xsd:restriction base="xsd:string">
      <xsd:enumeration value="Siteforce"/>
      <xsd:enumeration value="Visualforce"/>
-     <xsd:enumeration value="ChatterNetwork"/>
-     <xsd:enumeration value="ChatterNetworkPicasso"/>
      <xsd:enumeration value="User"/>
     </xsd:restriction>
    </xsd:simpleType>
@@ -2754,17 +2753,6 @@ Copyright 2006-2015 Salesforce.com, inc. All Rights Reserved
      <xsd:element name="object" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
     </xsd:sequence>
    </xsd:complexType>
-   <xsd:complexType name="DelegateGroup">
-    <xsd:complexContent>
-     <xsd:extension base="tns:Metadata">
-      <xsd:sequence>
-       <xsd:element name="label" type="xsd:string"/>
-       <xsd:element name="loginAccess" type="xsd:boolean"/>
-       <xsd:element name="name" type="xsd:string"/>
-      </xsd:sequence>
-     </xsd:extension>
-    </xsd:complexContent>
-   </xsd:complexType>
    <xsd:complexType name="EntitlementProcess">
     <xsd:complexContent>
      <xsd:extension base="tns:Metadata">
@@ -2906,14 +2894,10 @@ Copyright 2006-2015 Salesforce.com, inc. All Rights Reserved
    </xsd:simpleType>
    <xsd:simpleType name="ExternalDataSourceType">
     <xsd:restriction base="xsd:string">
-     <xsd:enumeration value="contentHubItem"/>
-     <xsd:enumeration value="Datacloud"/>
-     <xsd:enumeration value="ContentHubGDrive"/>
-     <xsd:enumeration value="ContentHubSharepointOneDrive"/>
-     <xsd:enumeration value="ContentHubSharepointOffice365"/>
      <xsd:enumeration value="Identity"/>
      <xsd:enumeration value="OData"/>
      <xsd:enumeration value="OData4"/>
+     <xsd:enumeration value="SfdcOrg"/>
      <xsd:enumeration value="SimpleURL"/>
      <xsd:enumeration value="Wrapper"/>
     </xsd:restriction>
@@ -4074,6 +4058,7 @@ Copyright 2006-2015 Salesforce.com, inc. All Rights Reserved
      <xsd:element name="highlightExternalFeedItems" minOccurs="0" type="xsd:boolean"/>
      <xsd:element name="leftComponents" minOccurs="0" maxOccurs="unbounded" type="tns:FeedLayoutComponent"/>
      <xsd:element name="rightComponents" minOccurs="0" maxOccurs="unbounded" type="tns:FeedLayoutComponent"/>
+     <xsd:element name="useInlineFiltersInConsole" minOccurs="0" type="xsd:boolean"/>
     </xsd:sequence>
    </xsd:complexType>
    <xsd:simpleType name="FeedLayoutFilterPosition">
@@ -4370,6 +4355,7 @@ Copyright 2006-2015 Salesforce.com, inc. All Rights Reserved
        <xsd:element name="customAgentName" minOccurs="0" type="xsd:string"/>
        <xsd:element name="enableAgentFileTransfer" minOccurs="0" type="xsd:boolean"/>
        <xsd:element name="enableAgentSneakPeek" minOccurs="0" type="xsd:boolean"/>
+       <xsd:element name="enableAssistanceFlag" minOccurs="0" type="xsd:boolean"/>
        <xsd:element name="enableAutoAwayOnDecline" minOccurs="0" type="xsd:boolean"/>
        <xsd:element name="enableAutoAwayOnPushTimeout" minOccurs="0" type="xsd:boolean"/>
        <xsd:element name="enableChatConferencing" minOccurs="0" type="xsd:boolean"/>
@@ -5294,15 +5280,15 @@ Copyright 2006-2015 Salesforce.com, inc. All Rights Reserved
    </xsd:complexType>
    <xsd:complexType name="PlatformCachePartitionType">
     <xsd:sequence>
-     <xsd:element name="allotedCapacity" type="xsd:int"/>
+     <xsd:element name="allocatedCapacity" type="xsd:int"/>
+     <xsd:element name="allocatedPurchasedCapacity" type="xsd:long"/>
      <xsd:element name="cacheType" type="tns:PlatformCacheType"/>
-     <xsd:element name="minimumCapacity" type="xsd:int"/>
     </xsd:sequence>
    </xsd:complexType>
    <xsd:simpleType name="PlatformCacheType">
     <xsd:restriction base="xsd:string">
-     <xsd:enumeration value="s"/>
-     <xsd:enumeration value="o"/>
+     <xsd:enumeration value="Session"/>
+     <xsd:enumeration value="Organization"/>
     </xsd:restriction>
    </xsd:simpleType>
    <xsd:complexType name="Portal">
@@ -7271,7 +7257,6 @@ Copyright 2006-2015 Salesforce.com, inc. All Rights Reserved
     <xsd:complexType>
      <xsd:sequence>
       <xsd:element name="client" type="xsd:string"/>
-      <xsd:element name="uiRequestId" type="xsd:string"/>
      </xsd:sequence>
     </xsd:complexType>
    </xsd:element>


### PR DESCRIPTION
Latest 35.0 metadata wsdl from my DE org.  The change to remove uiRequestId soap header is expected to fix the issue we have with workbench deploy in Winter' 16 orgs.