### PR TITLE
Change addLinksToIds to accept any 18-char base-62 string

### DIFF
--- a/workbench/shared.php
+++ b/workbench/shared.php
@@ -571,7 +571,7 @@ function natcaseksort($array) {
 
 
 function addLinksToIds($inputStr) {
-    $idMatcher = "/\b(\w{5}000\w{10})\b/";
+    $idMatcher = "/\b([A-Za-z0-9]{18})\b/";
     $uiHref = "href='" . getJumpToSfdcUrlPrefix() . "$1' target='sfdcUi' ";
 
     $dmlTip = "";


### PR DESCRIPTION
Salesforce doesn't seem to guarantee any zeros will appear in record IDs, so I believe the current addLinksToIds() function has an invalid regex for idMatcher.

https://github.com/ryanbrainard/forceworkbench/issues/679#issuecomment-214393526